### PR TITLE
Define api endpoints #24

### DIFF
--- a/forum/urls.py
+++ b/forum/urls.py
@@ -16,13 +16,23 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView, TokenVerifyView
+from rest_framework.routers import DefaultRouter
+from startups.views import StartupViewSet, ProjectViewSet
+from users.views import InvestorViewSet
 
+router = DefaultRouter()
+
+router.register(r'startups', StartupViewSet, basename='startups')
+router.register(r'projects', ProjectViewSet, basename='projects')
+router.register(r'investors', InvestorViewSet, basename='investors')
+# router.register(r'messages', MessageViewSet, basename='messages') #TODO: Implement the MessageViewSet logic
 
 urlpatterns = [
+    path('', include('startups.urls')),
     path('admin/', admin.site.urls),
+    path('api/', include(router.urls)),
     path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('api/token/verify/', TokenVerifyView.as_view(), name='token_verify'),
-    path('startups/', include('startups.urls')),
-    path('api/', include('users.urls')),
+    path('api/users/', include('users.urls')),
 ]

--- a/forum/utils.py
+++ b/forum/utils.py
@@ -1,0 +1,12 @@
+def get_query_dict(request):
+    """
+    The get_query_dict function takes in a request object and returns a dictionary of the query parameters.
+
+    :param request: Get the query parameters from the request object
+    :return: A dictionary of all the query parameters in a request
+    """
+    query_data = {}
+    query_params = request.GET
+    for key, value in query_params.items():
+        query_data[key] = value
+    return query_data

--- a/startups/urls.py
+++ b/startups/urls.py
@@ -13,10 +13,10 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.contrib import admin
-from django.urls import path, include
-from startups import views
+
+from django.urls import path
+from startups.views import StartupViewSet
 
 urlpatterns = [
-    path("", views.simple_json_view, name="mainpage"),
+    path("", StartupViewSet.as_view({'get': 'custom_method'}), name="startup_mainpage"),
 ]

--- a/startups/views.py
+++ b/startups/views.py
@@ -1,9 +1,238 @@
-from django.http import JsonResponse
+from forum.utils import get_query_dict
+
+from rest_framework import status
+from rest_framework import viewsets
+from rest_framework.response import Response
 
 
-def simple_json_view(request):
-    data = {
-        'message': 'Hello, STARTUP PAGE',
-        'status': 'success'
-    }
-    return JsonResponse(data)
+class StartupViewSet(viewsets.ViewSet):
+    """
+     ViewSet for managing startup resources.
+
+     This ViewSet provides standard CRUD operations for startups,
+     such as creating, retrieving a list, retrieving information about one startup,
+     updating, and deleting startups. Each operation is tied to the corresponding
+     HTTP method (GET, POST, PUT, PATCH, DELETE) and URL pattern.
+
+     Available methods:
+     - list: Retrieve a list of all startups (GET /api/startups/).
+     - retrieve: Retrieve information about one startup by its ID (GET /api/startups/{id}/).
+     - create: Create a new startup (POST /api/startups/).
+     - update: Fully update an existing startup by its ID (PUT /api/startups/{id}/).
+     - partial_update: Partially update an existing startup by its ID (PATCH /api/startups/{id}/).
+     - destroy: Delete a startup by its ID (DELETE /api/startups/{id}/).
+
+     Parameters:
+     - pk: The ID of the startup (used in retrieve, update, partial_update, and destroy methods).
+     - request: The request object, containing request data and parameters.
+
+     Request/Response Formats:
+     - Methods accept data in JSON format and also return responses in JSON format.
+     - Responses contain the status of the operation, messages, and startup data (in list, retrieve, create, update, partial_update operations).
+     """
+
+    def list(self, request):
+        # Implementation of GET METHOD - ExampLE URL: /api/startups/
+        # Getting ALL startups logic
+        data = {
+            'message': "Hello, ALL STARTUPS PROFILE PAGE",
+            'status': status.HTTP_200_OK
+        }
+        query_data = get_query_dict(request)  # If we need to use queries like /api/startups?name=Apple
+        if query_data:
+            data.update(query_data)
+        # Should return a list!
+        return Response(data, status=status.HTTP_200_OK)
+
+    def retrieve(self, request, pk=None):
+        # Implementation of GET METHOD for one startup - ExampLE URL: /api/startups/2
+        # Getting ONE startup with id=startup_id logic
+
+        startup_id = pk
+        data = {
+            'startup_id': startup_id,
+            'message': f"Hello, concrete STARTUP PROFILE PAGE WITH NUMBER {startup_id}",
+            'status': status.HTTP_200_OK
+        }
+
+        query_data = get_query_dict(request)  # If we need to use queries like /api/startups?name=AppleTV
+        if query_data:
+            data.update(query_data)
+        return Response(data, status=status.HTTP_200_OK)
+
+    def create(self, request):
+        # Implementation of POST METHOD for one startup - ExampLE URL: /api/startups/
+        # Do not forget slash at the end of link
+        # + you should send data in JSON
+        # Creating startup logic
+        startup_info = request.data
+        data = {
+            'startup_info': startup_info,
+            'status': 'success'
+        }
+        return Response(data, status=status.HTTP_201_CREATED)
+
+    def update(self, request, pk=None):
+        # Implementation of PUT METHOD for one startup - ExampLE URL: /api/startups/2/
+        # Do not forget about SLASH at the end of URL
+        # + you should send data in JSON
+        # PUT logic
+        startup_id = pk
+        startup_updated_info = request.data
+        data = {
+            'startup_id': startup_id,
+            'message': f"Hello, EDIT STARTUP PROFILE WITH NUMBER {startup_id}",
+            'updated_data': startup_updated_info,
+            'status': 'success'
+        }
+        return Response(data)
+
+    def partial_update(self, request, pk=None):
+        # Implementation of PATCH METHOD for one startup - ExampLE URL: /api/startups/2/
+        # Do not forget about SLASH at the end of URL
+        # + you should send data in JSON
+        # Pathcing logic
+        startup_id = pk
+        startup_specific_updated_info = request.data
+        data = {
+            'startup_id': startup_id,
+            'message': f"Hello, EDIT STARTUP PROFILE WITH NUMBER {startup_id}",
+            'specific_updated_data': startup_specific_updated_info,
+            'status': 'success'
+        }
+        return Response(data)
+
+    def destroy(self, request, pk=None):
+        # Implementation of DELETE METHOD for one startup - ExampLE URL: /api/startups/4/
+        # Do not forget about SLASH at the end of URL
+        # Deleting logic
+        startup_id = pk
+        data = {
+            'startup_id': startup_id,
+            'message': f"Hello, YOU DELETED Startup with ID: {startup_id}",
+            'status': 'success'
+        }
+        return Response(data)
+
+    # Maybe we will delete this but i'd like to whow you how it works :)
+    def custom_method(self, request):
+        data = {
+            'message': "Hello, this is custom GET method! We can use it for rendering pages",
+            'status': 'success'
+        }
+        return Response(data)
+
+
+class ProjectViewSet(viewsets.ViewSet):
+    """
+    ViewSet for managing project resources.
+
+    This ViewSet provides standard CRUD operations for projects,
+    including listing, retrieving, creating, updating, and deleting projects.
+    Each operation corresponds to an HTTP method (GET, POST, PUT, PATCH, DELETE)
+    and a URL pattern.
+
+    Available methods:
+    - list: Retrieve a list of all projects (GET /api/projects/).
+    - retrieve: Retrieve information about a specific project by its ID (GET /api/projects/{id}/).
+    - create: Create a new project (POST /api/projects/).
+    - update: Fully update an existing project by its ID (PUT /api/projects/{id}/).
+    - partial_update: Partially update an existing project by its ID (PATCH /api/projects/{id}/).
+    - destroy: Delete a project by its ID (DELETE /api/projects/{id}/).
+
+    Parameters:
+    - pk: The ID of the project (used in retrieve, update, partial_update, and destroy methods).
+    - request: The request object, containing request data and parameters.
+
+    Request/Response Formats:
+    - Methods accept data in JSON format and also return responses in JSON format.
+    - Responses contain the status of the operation, messages, and project data (in list, retrieve, create, update, partial_update operations).
+    """
+
+    def list(self, request):
+        # Implementation of GET METHOD - ExampLE URL: /api/projects/
+        # Getting ALL projects logic
+
+        data = {
+            'message': "Hello, ALL Projects PROFILE PAGE",
+            'status': status.HTTP_200_OK,
+        }
+        query_data = get_query_dict(request)  # If we need to use queries like /api/projects?name=Project1
+        if query_data:
+            data.update(query_data)
+
+        # Should return a list!
+        return Response(data, status=status.HTTP_200_OK)
+
+    def retrieve(self, request, pk=None):
+        # Implementation of GET METHOD for one project - ExampLE URL: /api/projects/2
+        # Getting ONE project with id=project logic
+
+        project_id = pk
+        data = {
+            'project_id': project_id,
+            'message': f"Hello, concrete PROJECT profile page with id {project_id}",
+            'status': status.HTTP_200_OK
+        }
+        query_data = get_query_dict(request)
+        if query_data:
+            data.update(query_data)
+
+        return Response(data, status=status.HTTP_200_OK)
+
+    def create(self, request):
+        # Implementation of POST METHOD for one project - ExampLE URL: /api/projects/
+        # Do not forget slash at the end of link
+        # + you should send data in JSON
+        # Creating project logic
+        project_info = request.data
+        data = {
+            'message': "You successfully created new project",
+            'project_info': project_info,
+            'status': status.HTTP_200_OK
+        }
+        return Response(data, status=status.HTTP_201_CREATED)
+
+    def update(self, request, pk=None):
+        # Implementation of PUT METHOD for one project - ExampLE URL: /api/projects/2/
+        # Do not forget about SLASH at the end of URL
+        # + you should send data in JSON
+        project_id = pk
+        project_updated_info = request.data
+        # ...
+        # PUT logic
+        # ...
+        data = {
+            'project_id': project_id,
+            'message': f"Hello, here's a PUT method! You update ALL information about PROJECT № {project_id}",
+            'updated_data': project_updated_info,
+            'status': status.HTTP_200_OK
+        }
+        return Response(data, status=status.HTTP_200_OK)
+
+    def partial_update(self, request, pk=None):
+        # Implementation of PATCH METHOD for one project - ExampLE URL: /api/projects/2/
+        # Do not forget about SLASH at the end of URL
+        # + you should send data in JSON
+        # PATCHcing logic
+        project_id = pk
+        project_specific_updated_info = request.data
+        data = {
+            'project_id': project_id,
+            'message': f"Hello, here's a PATCH method! You update SOME information about project № {project_id}",
+            'specific_updated_data': project_specific_updated_info,
+            'status': status.HTTP_200_OK
+        }
+        return Response(data, status=status.HTTP_200_OK)
+
+    def destroy(self, request, pk=None):
+        # Implementation of DELETE METHOD for one project - ExampLE URL: /api/projects/4/
+        # Do not forget about SLASH at the end of URL
+        # Deleting logic
+        project_id = pk
+        data = {
+            'project_id': project_id,
+            'message': f"Hello, you DELETED PROJECT with ID: {project_id}",
+            'status': status.HTTP_200_OK
+        }
+        return Response(data, status=status.HTTP_204_NO_CONTENT)

--- a/users/urls.py
+++ b/users/urls.py
@@ -14,7 +14,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
-from django.urls import path, include
+from django.urls import path
 from .views import UserRegisterAPIView, LoginAPIView, VerifyEmailAPIView
 
 

--- a/users/views.py
+++ b/users/views.py
@@ -1,3 +1,4 @@
+from forum.utils import get_query_dict
 from rest_framework import viewsets, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -23,17 +24,16 @@ class LoginAPIView(APIView):
 
         refresh = RefreshToken.for_user(user)
         refresh.payload.update({
-        'id': user.id,
-        'first_name': user.first_name,
-        'surname': user.surname
+            'id': user.id,
+            'username': user.username
         })
 
         return Response({
-                'refresh': str(refresh),
-                'access': str(refresh.access_token),
-            }, status=200)
-        
-        
+            'refresh': str(refresh),
+            'access': str(refresh.access_token),
+        }, status=200)
+
+
 class UserRegisterAPIView(APIView):
     def post(self, request):
         serializer = UserRegisterSerializer(data=request.data)
@@ -41,15 +41,16 @@ class UserRegisterAPIView(APIView):
             validated_data = serializer.validated_data
             custom_user = CustomUser.create_user(**validated_data)
             if custom_user:
-                
+
                 token = RefreshToken.for_user(custom_user).access_token
                 current_site = get_current_site(request).domain
                 relative_link = reverse('send_email_confirmation')
-                abs_url = 'http://'+ current_site + relative_link + '?token=' + str(token)
+                abs_url = 'http://' + current_site + relative_link + '?token=' + str(token)
                 email_body = 'Hi ' + custom_user.first_name + ' Use the link below to verify your email \n' + abs_url
-                sended_data = {'email_body': email_body, 'email_subject': 'Email confirmation', 'to_email': custom_user.email}
+                sended_data = {'email_body': email_body, 'email_subject': 'Email confirmation',
+                               'to_email': custom_user.email}
                 # Util.send_email(data=sended_data)
-                
+
                 return Response({"message": "User created successfully"}, status=status.HTTP_201_CREATED)
             else:
                 return Response({"message": "Failed to create user"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
@@ -60,3 +61,93 @@ class UserRegisterAPIView(APIView):
 class VerifyEmailAPIView(APIView):
     def get(self):
         pass
+
+
+class InvestorViewSet(viewsets.ViewSet):
+    def list(self, request):
+        # Implementation of GET METHOD - ExampLE URL: /api/investors/
+        # Getting ALL investors logic
+
+        data = {
+            'message': "Hello, GET all INVESTORS",
+            'status': status.HTTP_200_OK,
+        }
+        query_data = get_query_dict(request)  # If we need to use queries like /api/investors?name=JamesBond
+        if query_data:
+            data.update(query_data)
+
+        # Should return a list!
+        return Response(data, status=status.HTTP_200_OK)
+
+    def retrieve(self, request, pk=None):
+        # Implementation of GET METHOD for one investor - ExampLE URL: /api/investors/2
+        # Getting ONE investor with investors_id=pk logic
+
+        investor_id = pk
+        data = {
+            'investor_id': investor_id,
+            'message': f"Hello, concrete INVESTOR profile page with id {investor_id}",
+            'status': status.HTTP_200_OK
+        }
+        query_data = get_query_dict(request)  # If we need to use queries like /api/investors?name=JamesBond
+        if query_data:
+            data.update(query_data)
+
+        return Response(data, status=status.HTTP_200_OK)
+
+    def create(self, request):
+        # Implementation of POST METHOD for one investor - ExampLE URL: /api/investors/
+        # Do not forget slash at the end of link
+        # + you should send data in JSON
+        # Creating investor logic
+        investor_info = request.data
+        data = {
+            'message': "You successfully POSTed new INVESTOR",
+            'investor_info': investor_info,
+            'status': status.HTTP_200_OK
+        }
+        return Response(data, status=status.HTTP_201_CREATED)
+
+    def update(self, request, pk=None):
+        # Implementation of PUT METHOD for one investor - ExampLE URL: /api/investors/2/
+        # Do not forget about SLASH at the end of URL
+        # + you should send data in JSON
+        investor_id = pk
+        investor_updated_info = request.data
+        # ...
+        # PUT logic
+        # ...
+        data = {
+            'investor_id': investor_id,
+            'message': f"Hello, here's a PUT method! You update ALL information about INVESTOR № {investor_id}",
+            'updated_data': investor_updated_info,
+            'status': status.HTTP_200_OK
+        }
+        return Response(data, status=status.HTTP_200_OK)
+
+    def partial_update(self, request, pk=None):
+        # Implementation of PATCH METHOD for one investor - ExampLE URL: /api/investors/2/
+        # Do not forget about SLASH at the end of URL
+        # + you should send data in JSON
+        # PATCHcing logic
+        investor_id = pk
+        investor_specific_updated_info = request.data
+        data = {
+            'investor_id': investor_id,
+            'message': f"Hello, here's a PATCH method! You updated SOME information about INVESTOR № {investor_id}",
+            'specific_updated_data': investor_specific_updated_info,
+            'status': status.HTTP_200_OK
+        }
+        return Response(data, status=status.HTTP_200_OK)
+
+    def destroy(self, request, pk=None):
+        # Implementation of DELETE METHOD for one investor - ExampLE URL: /api/investors/4/
+        # Do not forget about SLASH at the end of URL
+        # Deleting logic
+        investor_id = pk
+        data = {
+            'investor_id': investor_id,
+            'message': f"Hello, you DELETED INVESTOR with ID: {investor_id}",
+            'status': status.HTTP_200_OK
+        }
+        return Response(data, status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
Created new viewsets and Define all API endpoints for managing startups, projects, and investors. 
These additions include the following:
- **StartupViewSet**: Handles CRUD operations for startups and supports query parameter handling for advanced filtering and search capabilities.
- **ProjectViewSet:** Manages projects with CRUD operations, also providing the ability to process query parameters.
- **InvestorViewSet:** Implements investor-related endpoints for listing, creating, updating, and deleting investors, with support for processing query parameters.

Additionally, updated urls.py to include routers for startups, projects, and investors, reassigned the users API, and created a future route for messages.