### PR TITLE
Added celery task for project subscription/Finish notifications implementation

### DIFF
--- a/forum/urls.py
+++ b/forum/urls.py
@@ -25,12 +25,14 @@ from rest_framework_simplejwt.views import (
     TokenVerifyView,
 )
 from startups.views import StartupViewSet
+from notifications.views import NotificationsViewSet
 
 router = DefaultRouter()
 
 router.register(r"startups", StartupViewSet, basename="startups")
 router.register(r"projects", ProjectViewSet, basename="projects")
 router.register(r"investors", InvestorViewSet, basename="investors")
+router.register(r"notifications", NotificationsViewSet, basename="notifications")
 # router.register(r'messages', MessageViewSet, basename='messages') #TODO: Implement the MessageViewSet logic
 
 
@@ -43,7 +45,6 @@ urlpatterns = [
     path("api/token/verify/", TokenVerifyView.as_view(), name="token_verify"),
     path("api/users/", include("users.urls")),
     path('api/investors/<int:pk>/follows/', InvestorViewSet.as_view({'get': 'all_subscribed_projects'}), name='investor_follows'),
-    path("api/notifications/", include("notifications.urls")),
     path("yasg/", include("forum.yasg")),
 
 ]

--- a/investors/views.py
+++ b/investors/views.py
@@ -4,11 +4,8 @@ from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-<<<<<<< HEAD
-=======
-
 from users.models import CustomUser
->>>>>>> main
+
 
 from projects.models import Project
 from projects.serializers import ProjectSerializer

--- a/notifications/models.py
+++ b/notifications/models.py
@@ -7,7 +7,7 @@ class Notification(mongoengine.Document):
     TYPES_OF_NOTIFICATIONS = [
         ("project_updating", "Project Updating"),
         ("investor_subscription", "Investors Subscription"),
-        ("new_message", "New Message")
+
     ]
     TYPES_OF_RECIPIENTS = [
         ("investor", "Investor"),

--- a/notifications/tasks.py
+++ b/notifications/tasks.py
@@ -10,6 +10,18 @@ from .utils import Util
 
 @shared_task(bind=True)
 def project_updating(self, investor_id, project_id, domain):
+    """
+    Celery task for notifying an investor about updates on a project.
+
+    Args:
+        self: The task instance.
+        investor_id (int): The ID of the investor to notify.
+        project_id (int): The ID of the project being updated.
+        domain (str): The domain name used to construct links in the notification email.
+
+    Returns:
+        str: A message indicating the completion of the task.
+    """
     project = Project.objects.get(id=project_id)
     investor = Investor.objects.get(id=investor_id)
     user = CustomUser.objects.get(id=investor.user_id)
@@ -35,6 +47,18 @@ def project_updating(self, investor_id, project_id, domain):
 
 @shared_task(bind=True)
 def project_subscription(self, project_id, subscriber_id, domain):
+    """
+    Celery task for notifying a startup owner about a new subscription by an investor.
+
+    Args:
+        self: The task instance.
+        project_id (int): The ID of the project being subscribed to.
+        subscriber_id (int): The ID of the investor subscribing to the project.
+        domain (str): The domain name used to construct links in the notification email.
+
+    Returns:
+        str: A message indicating the completion of the task.
+    """
     subscriber = Investor.objects.get(id=subscriber_id)
     subscriber_user = CustomUser.objects.get(id=subscriber.user_id)
     project = Project.objects.get(id=project_id)

--- a/notifications/tasks.py
+++ b/notifications/tasks.py
@@ -2,6 +2,7 @@ from celery import shared_task
 
 from investors.models import Investor
 from projects.models import Project
+from startups.models import Startup
 from users.models import CustomUser
 from .models import Notification
 from .utils import Util
@@ -30,3 +31,31 @@ def project_updating(self, investor_id, project_id, domain):
     }
     Util.send_email(sent_data)
     return "Project updating task completed"
+
+
+@shared_task(bind=True)
+def project_subscription(self, project_id, subscriber_id, domain):
+    subscriber = Investor.objects.get(id=subscriber_id)
+    subscriber_user = CustomUser.objects.get(id=subscriber.user_id)
+    project = Project.objects.get(id=project_id)
+    startup = Startup.objects.get(id=project.startup_id)
+    recipient_user = startup.owner
+    notification = Notification.create_notification(
+        recipient_type="startup",
+        recipient_id=recipient_user.id,
+        project_id=project_id,
+        type_of_notification="investor_subscription",
+        text=f"Investor {subscriber_user.first_name} {subscriber_user.last_name} subscribed to " +
+             f"Project with id {project_id}"
+    )
+    link = f"http://{domain}/api/projects/{project.id}"
+    sent_data = {
+        "email_subject": "New project subscription",
+        "email_body": f"Hello {recipient_user.first_name}!\n" +
+                      f"Investor {subscriber_user.first_name} {subscriber_user.last_name} subscribed " +
+                      f"to your project {project.project_name} with id # {project_id}\n" +
+                      f"Link to the project: {link}",
+        "to_email": startup.contact_email
+    }
+    Util.send_email(sent_data)
+    return "Project subscription task completed"

--- a/notifications/urls.py
+++ b/notifications/urls.py
@@ -1,7 +1,4 @@
 from django.urls import path
-from .views import NotificationListView, NotificationsAllView
 
-urlpatterns = [
-    path('new/', NotificationListView.as_view(), name='new_notifications'),
-    path('all/', NotificationsAllView.as_view(), name='all_notifications')
-]
+
+

--- a/notifications/views.py
+++ b/notifications/views.py
@@ -2,8 +2,9 @@ from rest_framework import status, viewsets
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from notifications.models import Notification
-from .serializers import NotificationSerializer
 from rest_framework.decorators import action
+
+from .serializers import NotificationSerializer
 
 
 class NotificationsViewSet(viewsets.ViewSet):

--- a/notifications/views.py
+++ b/notifications/views.py
@@ -1,6 +1,5 @@
 from rest_framework import status, viewsets
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.views import APIView
 from rest_framework.response import Response
 from notifications.models import Notification
 from .serializers import NotificationSerializer
@@ -8,10 +7,38 @@ from rest_framework.decorators import action
 
 
 class NotificationsViewSet(viewsets.ViewSet):
+    """
+    ViewSet for viewing notifications.
+
+    The ViewSet provides two `get` actions for viewing new (unread) notifications
+    and all notification for each user.
+
+    Available methods:
+    - GET: Returns a list of all unread notifications (GET /api/notifications/new/)
+    - GET: Returns a list of all notifications (GET /api/notifications/all)
+
+    Parameters:
+    - request: The request object, containing request data and parameters.
+
+    Request/Response Formats:
+    - Methods accept data in JSON format and also return responses in JSON format.
+    - Responses contain the status of the operation, messages, and project data (in list, retrieve, create, update,
+      partial_update operations).
+    """
     permission_classes = [IsAuthenticated]
 
     @action(detail=False, methods=['get'], url_path='new')
     def get_my_new_notifications(self, request):
+        """
+        Retrieve and mark as read all new (unread) notifications for the current user.
+
+        Args:
+            self: The view instance.
+            request: The request object.
+
+        Returns:
+            Response: A JSON response containing a list of new notifications.
+        """
         user = request.user
 
         notifications = Notification.get_unread_notifications(recipient_id=user.id, is_read=False)
@@ -27,6 +54,16 @@ class NotificationsViewSet(viewsets.ViewSet):
 
     @action(detail=False, methods=['get'], url_path='all')
     def get_my_all_notifications(self, request):
+        """
+        Retrieve all notifications for the current user.
+
+        Args:
+            self: The view instance.
+            request: The request object.
+
+        Returns:
+            Response: A JSON response containing a list of all notifications.
+        """
         user = request.user
 
         notifications = Notification.get_all_notifications(recipient_id=user.id)

--- a/notifications/views.py
+++ b/notifications/views.py
@@ -1,16 +1,17 @@
-from rest_framework import status
+from rest_framework import status, viewsets
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from notifications.models import Notification
 from .serializers import NotificationSerializer
+from rest_framework.decorators import action
 
 
-# Create your views here.
-class NotificationListView(APIView):
+class NotificationsViewSet(viewsets.ViewSet):
     permission_classes = [IsAuthenticated]
 
-    def get(self, request):
+    @action(detail=False, methods=['get'], url_path='new')
+    def get_my_new_notifications(self, request):
         user = request.user
 
         notifications = Notification.get_unread_notifications(recipient_id=user.id, is_read=False)
@@ -24,11 +25,8 @@ class NotificationListView(APIView):
 
         return Response(serializer.data, status=status.HTTP_200_OK)
 
-
-class NotificationsAllView(APIView):
-    permission_classes = [IsAuthenticated]
-
-    def get(self, request):
+    @action(detail=False, methods=['get'], url_path='all')
+    def get_my_all_notifications(self, request):
         user = request.user
 
         notifications = Notification.get_all_notifications(recipient_id=user.id)

--- a/projects/models.py
+++ b/projects/models.py
@@ -12,7 +12,6 @@ class Project(models.Model):
         ('completed', 'Completed'),
     ]
 
-
     startup = models.ForeignKey(Startup, on_delete=models.CASCADE, related_name='projects')
     project_name = models.CharField(max_length=255, unique=True)
     description = models.TextField(blank=True)
@@ -29,7 +28,6 @@ class Project(models.Model):
     subscribers = models.ManyToManyField("investors.Investor", related_name='subscribed_projects', blank=True)
     investors = models.ManyToManyField("investors.Investor", related_name='participated_projects', blank=True)
     is_active = models.BooleanField(default=True)
-
 
     class Meta:
         db_table = 'projects'

--- a/projects/views.py
+++ b/projects/views.py
@@ -11,7 +11,7 @@ from projects.serializers import ProjectSerializerUpdate, ProjectSerializer, Pro
 from projects.permissions import IsInvestor
 from projects.utils import filter_projects, calculate_difference
 from startups.models import Startup, Industry
-from notifications.tasks import project_updating
+from notifications.tasks import project_updating, project_subscription
 
 
 class ProjectViewSet(viewsets.ViewSet):
@@ -262,6 +262,10 @@ class ProjectViewSet(viewsets.ViewSet):
                               f'{project.project_name}.'}, status=status.HTTP_400_BAD_REQUEST)
 
             project.subscribers.add(subscriber)
+
+            current_site = get_current_site(request).domain
+            project_subscription.delay(project.id, subscriber.id, current_site)
+
             return Response({'message': f'Investor {user.first_name} {user.last_name} successfully subscribed to '
                                         f'the project {project.project_name}'}, status=status.HTTP_200_OK)
         except Project.DoesNotExist:


### PR DESCRIPTION
How to test notifications for project subscription:
1.  Run the server with `python manage.py runserver`.
2.  Run celery worker with `celery -A forum  worker -l info -P gevent`.
3.  Run `.../api/projects/{pk}/add_subscriber/` - To subscribe to the project as an investor.
4.  Check the startup email and Mongodb for a new notification.

![image](https://github.com/Project-Stage-Academy/UA_1155_alpha/assets/49594203/12914459-9ecf-4c03-9c27-bba353bb0854)
![image](https://github.com/Project-Stage-Academy/UA_1155_alpha/assets/49594203/0a66985c-2e95-428d-9ab9-19b35bd403fc)
