### PR TITLE
115 transfer notifications tasks for project updating to django signals

### DIFF
--- a/notifications/signals.py
+++ b/notifications/signals.py
@@ -1,12 +1,15 @@
 from django.contrib.sites.shortcuts import get_current_site
 from forum.middleware import get_current_request
 from django.db.models.signals import post_save
-from django.dispatch import receiver
+from django.dispatch import receiver, Signal
 
 from investors.models import Investor
 from projects.models import Project
 from startups.models import Startup
-from .tasks import send_for_moderation
+from .tasks import send_for_moderation, project_updating
+
+project_updated_signal = Signal()
+project_subscription_signal = Signal()
 
 
 @receiver(post_save, sender=Startup)
@@ -21,3 +24,13 @@ def profile_created_or_updated(sender, instance, created, **kwargs):
     model_name = sender.__name__
     data_id = instance.id
     send_for_moderation.delay(model_name, data_id, domain)
+
+
+@receiver(project_updated_signal)
+def project_updated(sender, investor_id, project_id, **kwargs):
+    """
+    Signal handler to perform actions when a project updated.
+    """
+    request = get_current_request()
+    current_site = get_current_site(request).domain if request else "localhost:8000/"
+    project_updating.delay(investor_id, project_id, current_site)

--- a/notifications/signals.py
+++ b/notifications/signals.py
@@ -6,7 +6,7 @@ from django.dispatch import receiver, Signal
 from investors.models import Investor
 from projects.models import Project
 from startups.models import Startup
-from .tasks import send_for_moderation, project_updating
+from .tasks import send_for_moderation, project_updating, project_subscription
 
 project_updated_signal = Signal()
 project_subscription_signal = Signal()
@@ -27,7 +27,7 @@ def profile_created_or_updated(sender, instance, created, **kwargs):
 
 
 @receiver(project_updated_signal)
-def project_updated(sender, investor_id, project_id, **kwargs):
+def project_updated_receiver(sender, investor_id, project_id, **kwargs):
     """
     Signal handler to perform actions when a project updated.
     """
@@ -36,4 +36,11 @@ def project_updated(sender, investor_id, project_id, **kwargs):
     project_updating.delay(investor_id, project_id, current_site)
 
 
-def project_subscription(sender, investor_)
+@receiver(project_subscription_signal)
+def project_subscription_receiver(sender, project_id, subscriber_id, **kwargs):
+    """
+    Signal handler to perform actions when an investor subscribes to a project.
+    """
+    request = get_current_request()
+    current_site = get_current_site(request).domain if request else "localhost:8000/"
+    project_subscription.delay(project_id, subscriber_id, current_site)

--- a/notifications/signals.py
+++ b/notifications/signals.py
@@ -34,3 +34,6 @@ def project_updated(sender, investor_id, project_id, **kwargs):
     request = get_current_request()
     current_site = get_current_site(request).domain if request else "localhost:8000/"
     project_updating.delay(investor_id, project_id, current_site)
+
+
+def project_subscription(sender, investor_)

--- a/projects/views.py
+++ b/projects/views.py
@@ -11,8 +11,7 @@ from projects.serializers import ProjectSerializerUpdate, ProjectSerializer, Pro
 from projects.permissions import IsInvestor
 from projects.utils import filter_projects, calculate_difference
 from startups.models import Startup, Industry
-from notifications.tasks import project_updating, project_subscription
-from notifications.signals import project_updated_signal
+from notifications.signals import project_updated_signal, project_subscription_signal
 
 
 class ProjectViewSet(viewsets.ViewSet):
@@ -261,8 +260,7 @@ class ProjectViewSet(viewsets.ViewSet):
 
             project.subscribers.add(subscriber)
 
-            current_site = get_current_site(request).domain
-            project_subscription.delay(project.id, subscriber.id, current_site)
+            project_subscription_signal.send(sender=Project, project_id=project.id, subscriber_id=subscriber.id)
 
             return Response({'message': f'Investor {user.first_name} {user.last_name} successfully subscribed to '
                                         f'the project {project.project_name}'}, status=status.HTTP_200_OK)


### PR DESCRIPTION
Created signals for project updating and project subscription to run celery tasks.
To check the functionality:
`../api/projects/<number>` with PUT or PATCH method to update the project.
`../api/projects/1/add_subscriber/` with POST method to subscribe to a project.
![image](https://github.com/Project-Stage-Academy/UA_1155_alpha/assets/49594203/94d6c69f-dc79-4707-b7da-bad0f40971c1)
![image](https://github.com/Project-Stage-Academy/UA_1155_alpha/assets/49594203/03061cc8-ce97-44a1-8c10-6a121c08a778)
